### PR TITLE
fix: copy MCP data files during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "track": "./dist/index.js"
   },
   "scripts": {
-    "build": "tsc",
+    "build": "tsc && cp -r src/mcp/data dist/mcp/",
     "dev": "tsc --watch",
     "mcp:start": "node dist/mcp/server.js",
     "mcp:dev": "npm run dev",


### PR DESCRIPTION
## Summary

• Updates build script to copy JSON data files to dist/mcp/data/ so the compiled CLI can access MCP server payloads
• Resolves ENOENT errors when running `node ./dist/index.js` 
• Ensures all MCP data files are available after the TypeScript compilation step

## Test plan

- [x] Build the project with `npm run build`
- [x] Verify data files are copied to dist/mcp/data/
- [x] Run `node ./dist/index.js --help` successfully
- [x] Test CLI commands work correctly after build
- [x] Check that existing tests still pass


💘 Generated with Crush